### PR TITLE
Add protected images

### DIFF
--- a/src/features/uploads/services/upload.service.ts
+++ b/src/features/uploads/services/upload.service.ts
@@ -1,6 +1,10 @@
 import { UTApi } from "uploadthing/server";
 import { FileObject } from "../interfaces/file.interface";
 
+const PROTECTED_IMAGES = [
+  'https://utfs.io/f/Ri7z8Bp5NkcuKusSJHzg7svjdQTeVIL2qyOpRG9W4XnzUto6'
+];
+
 export class UploadService {
   private utapi: UTApi;
 
@@ -98,7 +102,7 @@ export class UploadService {
         fileType = 'post-gif';
       }
 
-    const fileName = `${directory}/${userId || `user-${Date.now()}`}/${Date.now()}-${fileObject.fileName}`;
+      const fileName = `${directory}/${userId || `user-${Date.now()}`}/${Date.now()}-${fileObject.fileName}`;
 
       // Preparar metadata con información adicional
       const metadata = {
@@ -135,6 +139,11 @@ export class UploadService {
 
   private async deleteOldProfileImage(fileUrl: string): Promise<void> {
     try {
+
+      if (PROTECTED_IMAGES.includes(fileUrl)) {
+        console.log('Protected default image detected - skipping deletion');
+        return;
+      }
       // Extraer el fileKey de la URL
       // Las URLs de UploadThing suelen tener un formato como:
       // https://uploadthing.com/f/abc123-file.jpg


### PR DESCRIPTION

## Description
This PR adds support for protected images in the upload service. Protected images are designated as system defaults that cannot be deleted, ensuring they remain available as fallback options.

## Changes

### Added Protected Images Array
```typescript
const PROTECTED_IMAGES = [
  'https://utfs.io/f/Ri7z8Bp5NkcuKusSJHzg7svjdQTeVIL2qyOpRG9W4XnzUto6'
];
```

### Enhanced File Deletion Logic
Modified the `deleteOldProfileImage` method to check against the protected images list before attempting deletion:

```typescript
private async deleteOldProfileImage(fileUrl: string): Promise<void> {
  try {
    // Check if image is protected before deletion
    if (PROTECTED_IMAGES.includes(fileUrl)) {
      console.log('Protected default image detected - skipping deletion');
      return;
    }
    
    // Proceed with normal deletion...
    const fileKey = fileUrl.split('/').pop();
    
    // Rest of the deletion logic
  }
}
```

## Testing
- Verified that attempts to delete the protected image are properly skipped
- Confirmed that regular image deletion still functions correctly
- Checked logging output to ensure proper detection of protected images
