### PR TITLE
Update Dockerfile to use Node.js 22-alpine for builder and runner stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Setting the working directory in the container, to where things will be copied to and run from
 WORKDIR /app
@@ -15,7 +15,7 @@ RUN npm install --save-dev @types/yup
 RUN npm run build
 
 # Lightweight production image
-FROM node:18-alpine AS runner
+FROM node:22-alpine AS runner
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use a newer Node.js version for both the build and production stages.

Key changes:

* Updated the base image for the `builder` stage from `node:18-alpine` to `node:22-alpine` to leverage the latest features and improvements in Node.js. (`[DockerfileL1-R1](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1)`)
* Updated the base image for the `runner` stage from `node:18-alpine` to `node:22-alpine` for consistency and to ensure compatibility with the build stage. (`[DockerfileL18-R18](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R18)`)